### PR TITLE
refactor: replace error handler  func to function option for json handler func

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,18 +4,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/72sevenzy2/http-router/internal/response"
 	"github.com/72sevenzy2/http-router/internal/router"
+	"github.com/72sevenzy2/http-router/internal/test-handler"
 )
 
 func main() {
 	r := router.NewRouter()
 
-	r.Handle(http.MethodGet, "/hi", func(w http.ResponseWriter, r *http.Request) {
-		response.JSON(w, response.WithStatus(http.StatusOK), response.WithData(map[string]string{
-			"message": "hello",
-		}))
-	})
+	r.Handle(http.MethodPost, "/p", handler.HiHandler());
 
 	fmt.Println("server running on port 8080")
 	err := http.ListenAndServe(":8080", r)

--- a/internal/response/json.go
+++ b/internal/response/json.go
@@ -1,14 +1,15 @@
-package response 
+package response
 
 import (
-	"net/http"
 	"encoding/json"
+	"net/http"
 )
 
 type JsonOptions struct { // this struct will be modified via the ConfigOpts func
 	w      http.ResponseWriter
 	Data   interface{}
 	Status int
+	Error  string
 }
 
 type ConfigOpts func(*JsonOptions) // any func which returns this type ONLY will use a pointer to the JsonOptions struct like used here
@@ -17,6 +18,13 @@ type ConfigOpts func(*JsonOptions) // any func which returns this type ONLY will
 func WithStatus(status int) ConfigOpts {
 	return func(jo *JsonOptions) {
 		jo.Status = status
+	}
+}
+
+// with error param func
+func WithError(msg string) ConfigOpts {
+	return func(jo *JsonOptions) {
+		jo.Error = msg
 	}
 }
 
@@ -31,6 +39,7 @@ func WithData(data interface{}) ConfigOpts {
 type Response struct {
 	Data   interface{} `json:"data"`
 	Status int         `json:"status"`
+	Error  string      `json:"error"`
 }
 
 func JSON(w http.ResponseWriter, opts ...ConfigOpts) {
@@ -39,6 +48,7 @@ func JSON(w http.ResponseWriter, opts ...ConfigOpts) {
 		w:      w,
 		Status: http.StatusOK,
 		Data:   nil,
+		Error:  "",
 	}
 
 	// initialising each opt to the appropriate param func
@@ -52,18 +62,11 @@ func JSON(w http.ResponseWriter, opts ...ConfigOpts) {
 	response := &Response{
 		Data:   options.Data,
 		Status: options.Status,
+		Error:  options.Error,
 	} // initialising the response
 
-		err := json.NewEncoder(options.w).Encode(response) // handling errors while encoding it aswell
-		if err != nil {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-		}
-}
-
-// error json response helper
-func ERROR(w http.ResponseWriter, status int) {
-
-	JSON(w, WithStatus(status), WithData(map[string]string{
-		"error": http.StatusText(status),
-	}))
+	err := json.NewEncoder(options.w).Encode(response) // handling errors while encoding it aswell
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,8 +1,8 @@
 package router
 
 import (
-	"net/http"
 	"github.com/72sevenzy2/http-router/internal/response"
+	"net/http"
 )
 
 type Router struct { // initializing the router struct to hold all the routes
@@ -40,7 +40,7 @@ func (s *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handler, ok := method[r.Method] // assign the handler to the method type
 
 	if !ok {
-		response.ERROR(w, http.StatusMethodNotAllowed)
+		response.JSON(w, response.WithStatus(http.StatusMethodNotAllowed), response.WithError(http.StatusText(http.StatusMethodNotAllowed)))
 		return
 	}
 

--- a/internal/test-handler/hiHandler.go
+++ b/internal/test-handler/hiHandler.go
@@ -8,13 +8,13 @@ import (
 	"github.com/72sevenzy2/http-router/internal/response"
 )
 
-func hiHandler() http.HandlerFunc {
+func HiHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var i entity.Entity // initilising the entity
 
 		err := json.NewDecoder(r.Body).Decode(&i) // decoding the body to get the data we want
 		if err != nil {                           // if there is no data which we needed in the body, throw an json error msg
-			response.ERROR(w, http.StatusBadRequest)
+			response.JSON(w, response.WithStatus(http.StatusBadRequest), response.WithError(http.StatusText(http.StatusBadRequest)))
 			return
 		}
 		// respond with json returning the users user and the users id


### PR DESCRIPTION
changed error json handler func to an parameter function for the JSON func, so that i can pass it in as an error parameter in the json func itself instead of making it another function and calling it seperately for errors.